### PR TITLE
Fix the ABI version check.

### DIFF
--- a/src/gbm-platform.c
+++ b/src/gbm-platform.c
@@ -166,7 +166,8 @@ loadEGLExternalPlatform(int major, int minor,
                         EGLExtPlatform *platform)
 {
     if (!platform ||
-        !EGL_EXTERNAL_PLATFORM_VERSION_CHECK(major, minor)) {
+        !EGL_EXTERNAL_PLATFORM_VERSION_CMP(major, minor,
+            GBM_EXTERNAL_VERSION_MAJOR, GBM_EXTERNAL_VERSION_MINOR)) {
         return EGL_FALSE;
     }
 


### PR DESCRIPTION
This fixes the ABI version check in loadEGLExternalPlatform. It currently uses `EGL_EXTERNAL_PLATFORM_VERSION_CHECK`, which is correct for what `EGL_EXTERNAL_PLATFORM_HAS` does, but it's backwards from what we need to check the driver version.

This is the same fix as https://github.com/NVIDIA/egl-wayland/pull/106 is egl-wayland.