### PR TITLE
Also check for "nvidia_rm" from gbm_device_get_backend_name

### DIFF
--- a/src/gbm-display.c
+++ b/src/gbm-display.c
@@ -210,7 +210,7 @@ eGbmGetPlatformDisplayExport(void *dataVoid,
 
     if (data->ptr_gbm_device_get_backend_name != NULL) {
         const char *name = data->ptr_gbm_device_get_backend_name(display->gbm);
-        if (name == NULL || strcmp(name, "nvidia") != 0) {
+        if (name == NULL || (strcmp(name, "nvidia") != 0 && strcmp(name, "nvidia_rm") != 0)) {
             /*
              * This is not an NVIDIA device. Return failure, so that libglvnd can
              * move on to the next driver.


### PR DESCRIPTION
Some NVIDIA devices report a driver name of "nvidia_rm" from `gbm_device_get_backend_name`, rather than "nvidia", so egl-gbm needs to check for either of them to determine whether it's looking at an NVIDIA device.