### PR TITLE
Add ICD json file

### DIFF
--- a/src/15_nvidia_gbm.json
+++ b/src/15_nvidia_gbm.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libnvidia-egl-gbm.so.1"
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,3 +35,6 @@ egl_gbm = library('nvidia-egl-gbm',
     version : meson.project_version(),
     install : true,
 )
+
+install_data('15_nvidia_gbm.json',
+  install_dir: '@0@/egl/egl_external_platform.d'.format(get_option('datadir')))


### PR DESCRIPTION
For `egl-x11` we are shipping the ICD json loaders as part of the source. For `egl-gbm` we are not.

Also make sure the json file has the same name as the one that is shipped with the Nvidia driver.