### PR TITLE
Fix a segfault if drmGetDevices2 fails.

### DIFF
--- a/src/gbm-display.c
+++ b/src/gbm-display.c
@@ -133,7 +133,7 @@ OpenDefaultDrmDevice(void)
     int numDevices = drmGetDevices2(0, devices, 1);
     int fd = -1;
 
-    if (numDevices == 0)
+    if (numDevices <= 0)
         return -1;
 
     if (devices[0]->nodes[DRM_NODE_RENDER])


### PR DESCRIPTION
This fixes `OpenDefaultDrmDevice` to check for a failure in `drmGetDevices2`, rather than only checking if it succeeded but returned no devices.