### PR TITLE
Increment version number to 1.1.3.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('egl-gbm', 'c',
-        version : '1.1.2',
+        version : '1.1.3',
         default_options : [
           'buildtype=debugoptimized',
           'c_std=gnu99',


### PR DESCRIPTION
Just bumps the version number to 1.1.3 so that it's ready for the next tag.